### PR TITLE
raise exception if get request on iter_data fails

### DIFF
--- a/guillotina_gcloudstorage/storage.py
+++ b/guillotina_gcloudstorage/storage.py
@@ -111,6 +111,9 @@ class GCloudFileManager(object):
                     }, params={
                         'alt': 'media'
                     }, timeout=-1) as api_resp:
+                if api_resp.status != 200:
+                    text = await api_resp.text()
+                    raise GoogleCloudException(text)
                 while True:
                     chunk = await api_resp.content.read(1024 * 1024)
                     if len(chunk) > 0:


### PR DESCRIPTION
otherwise it was returning the contents of the failed response, for instance:
```
b'No such object: ....'
```