### PR TITLE
[1.x] Use quote_plus when starting multi part upload

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,9 @@
 1.1.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use quote_plus when starting multi part upload. Fixes issues
+  with `+` in content ids not working.
+  [vangheem]
 
 
 1.1.7 (2018-06-07)

--- a/guillotina_gcloudstorage/storage.py
+++ b/guillotina_gcloudstorage/storage.py
@@ -136,7 +136,7 @@ class GCloudFileManager(object):
 
         init_url = '{}&name={}'.format(
             UPLOAD_URL.format(bucket=await util.get_bucket_name()),
-            upload_file_id)
+            quote_plus(upload_file_id))
 
         async with aiohttp.ClientSession() as session:
 


### PR DESCRIPTION
 Fixes issues with `+` in content ids not working.