### PR TITLE
Add Ability to Query Individual Bucket Pages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,8 @@
 6.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add the ability to request specific pages from a bucket 
+  [OnnaRob]
 
 
 6.0.2 (2021-05-05)


### PR DESCRIPTION
Extends the existing `iterate_bucket()` method by breaking out the querying logic to allow for a request of a specific bucket page given there is a token provided. 